### PR TITLE
Launch Jupyter notebook redesign

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -1,212 +1,293 @@
-# Hugo Migration Project
+# Jupyter Notebook Redesign
 
 ## Overview
 
-**Goal:** Migrate from Jekyll to Hugo for faster builds, better templating, and more flexible hosting options.
+Personal website redesigned with Jupyter notebook-inspired interface for technical aesthetic while maintaining excellent readability.
 
-**Note:** This is the `hugo-migration` branch - focused purely on Hugo migration. For notebook aesthetic redesign, see the `redesign` branch.
-
-## Current State
-
-**Branch:** `hugo-migration`
-
-**Hugo migration:** ~98% complete
-- All content migrated and synced
-- Build system working and tested
-- GitHub Actions deployment configured
-- Ready for final testing and deployment
+**Branch:** `redesign`
+**Status:** Ready for production (Steps 1-2 complete)
 
 ---
 
-## Hugo Migration
+## Current State
 
-### What's Done
+### Completed
 
-- [x] Hugo installed and configured (`hugo-site/hugo.toml`)
-- [x] All 16 blog posts migrated to `hugo-site/content/posts/`
-- [x] All 5 navigation pages migrated (`_index.html`, `blog.html`, `books.html`, `articles.html`, `contact.html`)
-- [x] 2025 books synced to Hugo version of `books.html`
-- [x] Layouts created (`hugo-site/layouts/_default/`)
-- [x] CSS and fonts copied to `hugo-site/static/`
-- [x] Images and PDFs copied to `hugo-site/static/p/`
-- [x] URLs preserved exactly (including `soulbound(less)-tokens.html` with parentheses)
-- [x] Relative paths work correctly (images, PDFs)
-- [x] Build artifacts added to `.gitignore` (hugo-site/public/, .hugo_build.lock)
-- [x] Hugo build tested successfully (23 pages including 404, 32 static files)
-- [x] Development server tested and working
-- [x] All 16 blog posts tested (images, links, PDFs verified)
-- [x] Blog navigation links fixed (all have .html extensions)
-- [x] 404 page created (`hugo-site/layouts/404.html`)
-- [x] GitHub Actions workflow configured (`.github/workflows/hugo.yml`)
-- [x] Permalink configuration updated (deprecated :filename → :contentbasename)
-- [x] Hugo output compared with live Jekyll site (content matches)
+**Step 1 - Notebook pages (homepage + list pages):**
+- ✅ Notebook header with `maksym_sherman.ipynb` branding
+- ✅ Cell-based layout with execution counts (`In [n]:`, `Out[n]:`)
+- ✅ Python syntax highlighting in code cells
+- ✅ Navigation links styled as notebook output
+- ✅ DataFrame output for personal info
+- ✅ Substack newsletter embed in widget cell
+- ✅ List pages (blog/books/articles/contact) with notebook cells
 
-### Hugo Directory Structure
+**Step 2 - Blog posts:**
+- ✅ Notebook header added to all blog posts
+- ✅ Original typography and 55ch reading width preserved
+- ✅ No notebook cells (optimal reading experience)
+
+**Testing completed:**
+- ✅ Desktop browser testing (1080px viewport, Chrome)
+- ✅ Mobile browser testing (375px viewport, Chrome)
+- ✅ All navigation pages verified
+- ✅ 4 blog posts tested (various content types)
+- ✅ Link colors, typography, and layout confirmed
+
+### Not Yet Done
+
+**Cross-browser testing:**
+- [ ] Safari (desktop and iOS)
+- [ ] Firefox
+- [ ] Edge
+
+**Device testing:**
+- [ ] iPhone (actual device, not just viewport)
+- [ ] Android devices
+- [ ] iPad/tablets
+
+**Optional polish (Step 3):**
+- [ ] Hover state refinements
+- [ ] Spacing fine-tuning
+- [ ] Contrast checks (current colors pass WCAG AA)
+- [ ] 404 page with notebook theme
+
+---
+
+## Architecture
+
+### File Structure
 
 ```
 hugo-site/
 ├── hugo.toml                     # Hugo configuration
-├── content/
-│   ├── _index.html               # Homepage
-│   ├── blog.html                 # Blog listing page
-│   ├── books.html                # Books page (includes 2025 books)
-│   ├── articles.html             # Articles page
-│   ├── contact.html              # Contact page
-│   └── posts/                    # Blog posts (16 files)
-│       ├── art-clustering-in-renaissance-florence.html
-│       ├── live-nation.html
-│       ├── soulbound(less)-tokens.html
-│       └── ... (13 more)
 ├── layouts/
 │   ├── _default/
-│   │   ├── baseof.html           # Base template (head, analytics, CSS)
-│   │   ├── single.html           # Single page template (blog posts)
-│   │   └── list.html             # List template (sections)
-│   └── index.html                # Homepage layout
+│   │   ├── baseof.html           # Conditional CSS loading
+│   │   ├── single.html           # Blog posts (has header)
+│   │   └── notebook.html         # List pages layout
+│   ├── partials/
+│   │   └── notebook-header.html  # Shared header component
+│   └── index.html                # Homepage with full notebook UI
 ├── static/
-│   ├── main.css                  # Site styles with CSS variables
-│   ├── assets/
-│   │   ├── fonts/                # Inter font files
-│   │   └── images/               # Site images (hr.gif, etc.)
-│   └── p/
-│       ├── images/               # Blog post images
-│       └── pdfs/                 # PDF files
-└── public/                       # Build output (gitignored)
+│   ├── shared.css                # Fonts, variables, header styles
+│   ├── notebook.css              # Notebook UI (cells, syntax, layouts)
+│   └── main.css                  # Blog post typography (unchanged)
+└── content/
+    ├── _index.html               # Homepage
+    ├── blog.html                 # List pages (notebook layout)
+    ├── books.html
+    ├── articles.html
+    ├── contact.html
+    └── posts/                    # Blog posts (16 files)
 ```
 
-### Key Hugo Configuration (`hugo.toml`)
+### CSS Loading Strategy
 
-```toml
-uglyURLs = true                   # Creates .html files, not directories
-[permalinks]
-  posts = '/p/:contentbasename'   # Blog posts at /p/filename.html
-[markup.goldmark.renderer]
-  unsafe = true                   # Allows raw HTML in content
+**Conditional loading in baseof.html:**
+- All pages load: `shared.css` (fonts, header, variables)
+- Notebook pages load: `notebook.css` (homepage, blog/books/articles/contact)
+- Blog posts load: `main.css` (original typography)
+
+**Critical:** Never load `main.css` and `notebook.css` together to prevent style conflicts.
+
+### Key Design Decisions
+
+1. **Notebook pages (homepage + lists):** Full cell-based layout with 700px max-width
+2. **Blog posts:** Header only, no cells, 55ch reading width preserved
+3. **Typography:** Blog posts use proven `main.css` styles for optimal readability
+4. **Colors:** Golden yellow links (#ffcc00), VS Code dark theme palette
+5. **Header:** Fixed positioning, always visible on scroll
+6. **Manual content:** All list pages remain hand-curated (no auto-generation)
+
+---
+
+## Color Scheme
+
+### Background
+- Primary: `#1e1e1e` (dark), gradient: `linear-gradient(#2a2a29, #1c1c1c)`
+- Cell backgrounds: `#2d2d2d`
+- Header: `#252526`
+
+### Text
+- Primary: `#e0e0e0` (light gray)
+- Secondary: `#a0a0a0` (medium gray)
+- Blog posts: `#f0e7d5` (warm cream)
+
+### Accents
+- Links: `#ffcc00` (golden yellow)
+- Link hover: `#ffeb9b` (lighter golden)
+- Blue (execution counts): `#4fc3f7`
+- Green (kernel dot): `#81c784`
+- Purple (keywords): `#b39ddb`
+- Yellow (functions): `#fff176`
+
+### Book Ratings
+- Green: `#a8e6a0` (9-10/10)
+- Blue: `#64b5f6` (7-8/10)
+- Gray: `#b0b0b0` (5-6/10)
+
+---
+
+## Cell Types
+
+### Code Cells
+Display Python-style code with syntax highlighting:
+```html
+<div class="cell code-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">In [</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="code-input"><span class="keyword">from</span> <span class="variable">world</span>...</div>
+    </div>
+  </div>
+</div>
 ```
 
-### What's Left for Hugo Migration
+### Output Cells
+Display execution results (DataFrames, lists, navigation):
+- DataFrame output: Table with borders, monospace font
+- Navigation output: Vertical list of links with icons and metadata
+- List content: 55ch max-width for readability
 
-- [ ] Verify mobile responsiveness on actual devices
-- [ ] Enable GitHub Pages in repository settings (Settings → Pages → Source: GitHub Actions)
-- [ ] Test deployment workflow on main branch
-- [ ] Verify live site after deployment
-- [ ] Clean up old Jekyll files from repo root after migration is confirmed working
-- [ ] Optional: Add RSS feed if desired (currently disabled in hugo.toml)
+### Markdown Cells
+Formatted text without execution counts (empty gutter)
 
-### To Test Hugo Locally
+### Widget Cells
+External embeds (Substack newsletter)
+
+---
+
+## Critical Implementation Details
+
+### Code Cell Formatting
+**MUST** place code content on same line as opening tag to prevent whitespace misalignment:
+
+```html
+<!-- CORRECT -->
+<div class="code-input"><span class="variable">me</span>.<span class="function">list_posts</span>()</div>
+
+<!-- WRONG - creates whitespace -->
+<div class="code-input">
+  <span class="variable">me</span>.<span class="function">list_posts</span>()
+</div>
+```
+
+### Header Fixed Positioning
+- Header uses `position: fixed` (not sticky)
+- Body has `padding-top: 40px` to prevent content hiding
+- Header links to homepage (/)
+
+### Manual Counts
+Navigation card counts must be updated manually:
+- Blog posts: Update in `content/_index.html`
+- Books: Currently 160
+- Articles: Currently 70
+
+---
+
+## Testing Locally
 
 ```bash
 cd hugo-site
-hugo server
+hugo server --noHTTPCache --disableFastRender
 ```
 
-Visit http://localhost:1313/
+Visit: http://localhost:1313/
 
-### GitHub Actions Deployment
-
-The site is configured to deploy automatically via GitHub Actions:
-
-**Workflow file:** `.github/workflows/hugo.yml`
-
-**How it works:**
-1. Triggers on push to `main` branch or manual workflow dispatch
-2. Builds Hugo site from `hugo-site/` directory
-3. Uses Hugo v0.154.0 (extended) with minification
-4. Deploys to GitHub Pages
-
-**To enable:**
-1. Go to repository Settings → Pages
-2. Set Source to "GitHub Actions"
-3. Merge `hugo-migration` branch to `main`
-4. Workflow will automatically deploy
+**Hard refresh to clear cache:**
+- Mac: `Cmd + Shift + R`
+- Windows/Linux: `Ctrl + F5`
 
 ---
 
-## Branch Structure
+## Deployment
 
-This repository has multiple branches for different purposes:
+**Platform:** GitHub Pages via GitHub Actions
 
-- **`main`** - Production Jekyll site (currently live at msherman.xyz)
-- **`hugo-migration`** (this branch) - Hugo migration work only, no notebook styling
-- **`redesign`** - Notebook aesthetic prototypes and styling (for future implementation)
+**Process:**
+1. Merge `redesign` branch to `main`
+2. GitHub Actions automatically builds and deploys
+3. Verify live site at https://msherman.xyz/
 
----
-
-## Files Changed from Main Branch
-
-Key files modified/added on `hugo-migration` branch:
-
-### New
-- `hugo-site/` - Complete Hugo site structure
-- `claude.md` - This documentation file
-- `.gitignore` - Updated with Hugo build artifacts
-
-### Modified in Root (from main branch updates)
-- `books.html` - 2025 books added, CSS variables for colors
-- `main.css` - CSS variables added for book colors
-- `index.html` - Minor updates
-- Several blog posts in `p/` directory
-
-### To Clean Up After Migration
-Once Hugo deployment is confirmed working, these Jekyll files can be removed from root:
-- `_layouts/` - Jekyll layouts (if they exist)
-- `_includes/` - Jekyll includes (if they exist)
-- `_config.yml` - Jekyll config (if it exists)
-- `Gemfile`, `Gemfile.lock` - Jekyll dependencies
+**GitHub Actions workflow:** `.github/workflows/hugo.yml`
+- Builds from `hugo-site/` directory
+- Uses Hugo v0.154.0 (extended)
+- Deploys on push to `main`
 
 ---
 
-## Quick Commands
+## Known Issues & Solutions
 
-```bash
-# Test Hugo locally
-cd hugo-site && hugo server
+### Issue: Code cell text misalignment
+**Cause:** HTML newlines after `<div class="code-input">` create whitespace
+**Solution:** Keep code on same line as opening tag (see Critical Implementation Details)
 
-# Build Hugo site
-cd hugo-site && hugo --cleanDestinationDir
-
-# Check what Hugo generates
-ls -la hugo-site/public/
-
-# Compare with live site
-open https://msherman.xyz/p/art-clustering-in-renaissance-florence.html
-open http://localhost:1313/p/art-clustering-in-renaissance-florence.html
-```
+### Issue: Header jumps during scroll
+**Cause:** Using `position: sticky`
+**Solution:** Changed to `position: fixed` with `left: 0, right: 0, width: 100%`
 
 ---
 
-## Next Steps
+## Future Enhancement Ideas
 
-Priority tasks for completing Hugo migration:
+Optional improvements (not required for launch):
 
-1. **Test all 16 blog posts thoroughly**
-   - Verify images load correctly
-   - Check PDF links work
-   - Test internal and external links
-   - Verify mobile responsiveness
+- [ ] Add Python execution (via Pyodide) for interactive demos
+- [ ] Implement code folding for long snippets
+- [ ] Add "copy code" buttons to code cells
+- [ ] Create notebook-themed 404 page
+- [ ] Add search functionality styled as code input
+- [ ] Implement light theme toggle
+- [ ] Add animations for cell execution
+- [ ] RSS feed styled as Python import
+- [ ] Additional hover state polish
+- [ ] Spacing and contrast micro-adjustments
 
-2. **Set up GitHub Actions for deployment**
-   - Hugo doesn't have native GitHub Pages support like Jekyll
-   - Need workflow to build and deploy to gh-pages branch or custom hosting
-   - Consider deployment options (GitHub Pages, Netlify, Vercel, etc.)
+---
 
-3. **Add 404 page**
-   - Create `hugo-site/layouts/404.html`
-   - Test 404 handling
+## Quick Reference
 
-4. **Final testing**
-   - Compare Hugo output with live site
-   - Mobile responsiveness check
-   - Performance testing
+### Manual Updates Needed
 
-5. **Switch to production**
-   - Update deployment to use Hugo
-   - Clean up old Jekyll files from root
-   - Update main branch with Hugo site
+**Adding a new blog post:**
+1. Create HTML file in `hugo-site/content/posts/`
+2. Update count in `hugo-site/content/_index.html` navigation
+3. Add link to `hugo-site/content/blog.html`
 
-## Future Work (Separate Branch)
+**Adding a new book:**
+1. Add entry to `hugo-site/content/books.html`
+2. Use inline style for color: `style="color: var(--book-green)"`
+3. Update count in `hugo-site/content/_index.html` if needed
 
-For notebook aesthetic redesign, switch to the `redesign` branch which contains:
-- `prototype-index.html` - Notebook UI prototype
-- `notebook.css` - Notebook styling
-- Implementation plan for applying notebook aesthetic to navigation pages
+**Typography rules:**
+- Notebook pages: 16px base, line-height 1.6
+- Blog posts: 16px base (from main.css)
+- Code cells: 14px monospace
+- Max-width: 700px for notebook container, 55ch for reading text
+
+---
+
+## Design Philosophy
+
+**Core principle:** Notebook metaphor creates authentic technical aesthetic for navigation, but steps back for blog posts to prioritize reading experience.
+
+**Why Jupyter notebooks?**
+- Familiar to technical audiences (data scientists, developers)
+- Cell-based layout organizes content naturally
+- Code aesthetic signals technical credibility
+- Interactive, exploratory feel
+
+**Why simplify blog posts?**
+- Reading long-form content in cells is exhausting
+- Original typography is proven and readable
+- Notebook header provides enough branding
+- Focus on ideas, not interface
+
+---
+
+**Last Updated:** 2026-01-02
+**Branch:** redesign
+**Status:** Production-ready (Steps 1-2 complete, Step 3 optional)

--- a/hugo-site/content/articles.html
+++ b/hugo-site/content/articles.html
@@ -1,7 +1,26 @@
 ---
 title: "Article List"
+layout: "notebook"
 ---
-<h1>Article List</h1>
+<div class="cell code-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">In [</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="code-input"><span class="variable">me</span>.<span class="function">list_articles</span>(by=<span class="string">"rating"</span>)</div>
+    </div>
+  </div>
+</div>
+
+<div class="cell output-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">Out[</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="list-content">
+        <h1>Article List</h1>
 <p>This is a list of the best articles that I&#39;ve read. </p>
 <p>10/10:</p>
 <ul>
@@ -84,3 +103,7 @@ title: "Article List"
     <li> <a href="https://hbr.org/1973/01/clear-writing-means-clear-thinking-means">Clear Writing Means Clear Thinking Means...</a> </li>
     <li> <a href="https://www.henrikkarlsson.xyz/p/looking-for-alice">Looking for Alice</a> </li>
 <ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/hugo-site/content/blog.html
+++ b/hugo-site/content/blog.html
@@ -1,25 +1,48 @@
 ---
 title: "Blog"
+layout: "notebook"
 ---
-<h1>Blog</h1>
-<h3>2025</h3>
-<p><a href="p/striking_while_the_iron_is_hot.html">Lyndon Johnson and Robert Caro: Striking While the Iron is Hot</a></p>
-<p><a href="p/unpredictable.html">Unpredictable</a></p>
-<p><a href="p/boi-favorite-book.html">The Beginning of Infinity - My Favorite Book</a></p>
-<p><a href="p/soulbound(less)-tokens.html">Soulbound(less) Tokens</a></p>
-<h3>2024</h3>
-<p><a href="p/art-clustering-in-renaissance-florence.html">Art Clustering in Renaissance Florence</a></p>
-<p><a href="p/knowledge-without-explanation.html">Knowledge without Explanation</a></p>
-<p><a href="p/reasoning-by-inertia.html">Reasoning by Inertia</a></p>
-<h3>2023</h3>
-<p><a href="p/live-nation.html">Live Nation Overview</a></p>
-<p><a href="p/some-thoughts.html">Some Thoughts</a></p>
-<p><a href="p/men-and-rubber.html">Men and Rubber (Book Notes)</a></p>
-<p><a href="p/newsletter-publishing-platforms.html">The Future of Substack and Newsletter Publishing Platforms</a></p>
-<p><a href="p/7powers-vs-blockchain.html">7 Powers vs. Blockchain</a></p>
-<h3>2022</h3>
-<p><a href="p/beyond-blockchain-marketplaces.html">Beyond Blockchain Marketplaces</a></p>
-<h3>2021</h3>
-<p><a href="p/the-known-world.html">The Known World</a></p>
-<p><a href="p/perverse-incentives-and-airdrops.html">Perverse Incentives and Airdrops</a></p>
-<p><a href="p/to-the-lighthouse.html">To The Lighthouse</a></p>
+<div class="cell code-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">In [</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="code-input"><span class="variable">me</span>.<span class="function">list_posts</span>(by=<span class="string">"year"</span>)</div>
+    </div>
+  </div>
+</div>
+
+<div class="cell output-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">Out[</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="list-content">
+        <h1>Blog</h1>
+        <h3>2025</h3>
+        <p><a href="p/striking_while_the_iron_is_hot.html">Lyndon Johnson and Robert Caro: Striking While the Iron is Hot</a></p>
+        <p><a href="p/unpredictable.html">Unpredictable</a></p>
+        <p><a href="p/boi-favorite-book.html">The Beginning of Infinity - My Favorite Book</a></p>
+        <p><a href="p/soulbound(less)-tokens.html">Soulbound(less) Tokens</a></p>
+        <h3>2024</h3>
+        <p><a href="p/art-clustering-in-renaissance-florence.html">Art Clustering in Renaissance Florence</a></p>
+        <p><a href="p/knowledge-without-explanation.html">Knowledge without Explanation</a></p>
+        <p><a href="p/reasoning-by-inertia.html">Reasoning by Inertia</a></p>
+        <h3>2023</h3>
+        <p><a href="p/live-nation.html">Live Nation Overview</a></p>
+        <p><a href="p/some-thoughts.html">Some Thoughts</a></p>
+        <p><a href="p/men-and-rubber.html">Men and Rubber (Book Notes)</a></p>
+        <p><a href="p/newsletter-publishing-platforms.html">The Future of Substack and Newsletter Publishing Platforms</a></p>
+        <p><a href="p/7powers-vs-blockchain.html">7 Powers vs. Blockchain</a></p>
+        <h3>2022</h3>
+        <p><a href="p/beyond-blockchain-marketplaces.html">Beyond Blockchain Marketplaces</a></p>
+        <h3>2021</h3>
+        <p><a href="p/the-known-world.html">The Known World</a></p>
+        <p><a href="p/perverse-incentives-and-airdrops.html">Perverse Incentives and Airdrops</a></p>
+        <p><a href="p/to-the-lighthouse.html">To The Lighthouse</a></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/hugo-site/content/books.html
+++ b/hugo-site/content/books.html
@@ -1,7 +1,26 @@
 ---
 title: "Book List"
+layout: "notebook"
 ---
-<h1>Book List</h1>
+<div class="cell code-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">In [</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="code-input"><span class="variable">me</span>.<span class="function">list_books</span>(by=<span class="string">"year"</span>, with_ratings=<span class="builtin">True</span>)</div>
+    </div>
+  </div>
+</div>
+
+<div class="cell output-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">Out[</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="list-content">
+        <h1>Book List</h1>
 <p>This is a list of books that I&#39;ve read. </p>
 <p>Books that I thought were phenomenal are highlighted in <a style="color:var(--book-green);">green</a>, 
   books that I thought were particularly great are highlighted in <a style="color:var(--book-blue);">blue</a>, 
@@ -187,3 +206,7 @@ title: "Book List"
     <li> <a href="https://www.amazon.com/Handmaids-Tale-Margaret-Atwood/dp/0307264602"style="color:var(--book-gray);">The Handmaid&#39;s Tale</a> </li>
     <li> <a href="https://www.amazon.com/Slaughterhouse-Five-Novel-Modern-Library-Novels/dp/0385333846"style="color:var(--book-gray);">Slaughterhouse-Five</a> </li>
  </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/hugo-site/content/contact.html
+++ b/hugo-site/content/contact.html
@@ -1,6 +1,29 @@
 ---
 title: "Contact"
+layout: "notebook"
 ---
-<h1>Contact</h1>
-The best way to contact me is by email: hi [at] maksymsherman.com or
-<a href="https://twitter.com/MaksymSherman">Twitter</a>.
+<div class="cell code-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">In [</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="code-input"><span class="variable">me</span>.<span class="function">get_contact_info</span>()</div>
+    </div>
+  </div>
+</div>
+
+<div class="cell output-cell">
+  <div class="cell-content">
+    <div class="cell-gutter">
+      <span class="bracket">Out[</span>1<span class="bracket">]:</span>
+    </div>
+    <div class="cell-body">
+      <div class="list-content">
+        <h1>Contact</h1>
+        The best way to contact me is by email: hi [at] maksymsherman.com or
+        <a href="https://twitter.com/MaksymSherman">Twitter</a>.
+      </div>
+    </div>
+  </div>
+</div>

--- a/hugo-site/layouts/_default/baseof.html
+++ b/hugo-site/layouts/_default/baseof.html
@@ -13,7 +13,16 @@
     gtag('config', 'G-TR23NDH2MP');
   </script>
   <script defer src="https://cloud.umami.is/script.js" data-website-id="621725b9-29f5-45d4-a844-ccce88020346"></script>
-  <link rel="stylesheet" href="/main.css">
+
+  <!-- Shared CSS: fonts, variables, notebook header, blog helpers -->
+  <link rel="stylesheet" href="/shared.css">
+
+  <!-- Conditional CSS: notebook.css for homepage + list pages, main.css for blog posts -->
+  {{ if or .IsHome (eq .Params.layout "notebook") }}
+    <link rel="stylesheet" href="/notebook.css">
+  {{ else }}
+    <link rel="stylesheet" href="/main.css">
+  {{ end }}
 
   <title>{{ .Title | default .Site.Title }}</title>
   <style>

--- a/hugo-site/layouts/_default/notebook.html
+++ b/hugo-site/layouts/_default/notebook.html
@@ -1,5 +1,7 @@
 {{ define "main" }}
 {{ partial "notebook-header.html" . }}
 
-{{ .Content }}
+<main class="notebook list-page">
+  {{ .Content }}
+</main>
 {{ end }}

--- a/hugo-site/layouts/index.html
+++ b/hugo-site/layouts/index.html
@@ -1,3 +1,138 @@
 {{ define "main" }}
-{{ .Content }}
+{{ partial "notebook-header.html" . }}
+
+<main class="notebook">
+  <!-- Cell 1: Import -->
+  <div class="cell code-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">In [</span>1<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="code-input"><span class="keyword">from</span> <span class="variable">world</span> <span class="keyword">import</span> <span class="function">Person</span>
+<span class="variable">me</span> = <span class="function">Person</span>(<span class="string">"Maksym Sherman"</span>)</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cell 2: Intro (markdown) -->
+  <div class="cell markdown-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"></div>
+      <div class="cell-body">
+        <h1>Hi, I'm Maksym!</h1>
+        <p>I believe in great work, ambition, and obsessiveness. I seek to understand the world through better explanations.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cell 3: Describe -->
+  <div class="cell code-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">In [</span>2<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="code-input"><span class="variable">me</span>.<span class="function">describe</span>()</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="cell output-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">Out[</span>2<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="dataframe-output">
+          <table class="dataframe">
+            <thead>
+              <tr><th></th><th>status</th><th>description</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="index">currently</td>
+                <td>Economic consulting</td>
+                <td>Focused on data work</td>
+              </tr>
+              <tr>
+                <td class="index">previously</td>
+                <td>OurNetwork</td>
+                <td>Crypto data newsletter</td>
+              </tr>
+              <tr>
+                <td class="index">always</td>
+                <td>Looking to connect</td>
+                <td>Curious people and ideas</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cell 4: Navigation -->
+  <div class="cell code-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">In [</span>3<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="code-input"><span class="variable">me</span>.<span class="function">get_sections</span>()  <span class="comment"># Explore my work</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="cell output-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">Out[</span>3<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="nav-output">
+          <a href="blog.html" class="nav-link">
+            <span class="nav-icon">&#128221;</span>
+            <div class="nav-content">
+              <div class="nav-title">blog <span class="nav-arrow">→</span></div>
+            </div>
+            <div class="nav-meta"></div>
+          </a>
+          <a href="books.html" class="nav-link">
+            <span class="nav-icon">&#128218;</span>
+            <div class="nav-content">
+              <div class="nav-title">books <span class="nav-arrow">→</span></div>
+            </div>
+            <div class="nav-meta"></div>
+          </a>
+          <a href="articles.html" class="nav-link">
+            <span class="nav-icon">&#128279;</span>
+            <div class="nav-content">
+              <div class="nav-title">articles <span class="nav-arrow">→</span></div>
+            </div>
+            <div class="nav-meta"></div>
+          </a>
+          <a href="contact.html" class="nav-link">
+            <span class="nav-icon">&#128231;</span>
+            <div class="nav-content">
+              <div class="nav-title">contact <span class="nav-arrow">→</span></div>
+            </div>
+            <div class="nav-meta"></div>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cell 5: Newsletter -->
+  <div class="cell code-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">In [</span>4<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="code-input"><span class="variable">me</span>.<span class="function">subscribe</span>()  <span class="comment"># Get notified of new posts</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="cell widget-cell">
+    <div class="cell-content">
+      <div class="cell-gutter"><span class="bracket">Out[</span>4<span class="bracket">]:</span></div>
+      <div class="cell-body">
+        <div class="widget-container">
+          <iframe src="https://maksymsherman.substack.com/embed" width="480" height="320" frameborder="0"></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
 {{ end }}

--- a/hugo-site/layouts/partials/notebook-header.html
+++ b/hugo-site/layouts/partials/notebook-header.html
@@ -1,0 +1,12 @@
+<header class="notebook-header">
+  <div class="notebook-toolbar">
+    <a href="/" class="notebook-title">
+      <span class="icon">&#128211;</span>
+      <span>maksym_sherman.ipynb</span>
+    </a>
+    <div class="kernel-indicator">
+      <span class="kernel-dot"></span>
+      <span>Maksym Sherman (active)</span>
+    </div>
+  </div>
+</header>

--- a/hugo-site/static/notebook.css
+++ b/hugo-site/static/notebook.css
@@ -1,0 +1,520 @@
+/* ============================================
+   NOTEBOOK.CSS - Jupyter-inspired UI theme
+   ============================================
+   Loaded only on notebook pages (homepage + list pages)
+   NEVER loaded together with main.css
+   ============================================ */
+
+/* ============================================
+   CSS VARIABLES
+   ============================================ */
+
+:root {
+  /* Background colors */
+  --bg-primary: #1e1e1e;
+  --bg-secondary: #252526;
+  --bg-cell: #2d2d2d;
+  --bg-cell-hover: #323232;
+  --bg-code-input: #1e1e1e;
+
+  /* Text colors */
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0a0;
+  --text-muted: #6a6a6a;
+  --text-execution: #7c7c7c;
+
+  /* Accent colors */
+  --accent-blue: #4fc3f7;
+  --accent-green: #81c784;
+  --accent-orange: #ffb74d;
+  --accent-purple: #b39ddb;
+  --accent-yellow: #fff176;
+
+  /* Border & UI */
+  --border-color: #3c3c3c;
+  --link-color: #ffcc00;
+  --link-hover: #ffeb9b;
+}
+
+/* ============================================
+   BASE STYLES
+   ============================================ */
+
+html {
+  background: linear-gradient(#2a2a29, #1c1c1c);
+  min-height: 100vh;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  padding-top: 40px; /* Override to account for fixed header */
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+/* ============================================
+   NOTEBOOK CONTAINER
+   ============================================ */
+
+.notebook {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 20px 16px 60px;
+}
+
+/* ============================================
+   CELL-BASED LAYOUT
+   ============================================ */
+
+.cell {
+  margin-bottom: 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  border-left: 3px solid transparent;
+  transition: all 0.2s ease;
+}
+
+.cell:hover {
+  border-color: var(--border-color);
+  border-left-color: var(--accent-blue);
+}
+
+.cell-content {
+  display: flex;
+  align-items: flex-start;
+}
+
+.cell-gutter {
+  width: 50px;
+  flex-shrink: 0;
+  text-align: right;
+  padding-right: 8px;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 12px;
+  color: var(--text-execution);
+  user-select: none;
+  padding-top: 12px;
+}
+
+.cell-gutter .bracket {
+  color: var(--accent-blue);
+}
+
+.cell-body {
+  flex: 1;
+  padding: 10px 16px 10px 0;
+  min-width: 0;
+}
+
+/* ============================================
+   CODE CELLS
+   ============================================ */
+
+.code-cell .cell-body {
+  padding: 0;
+}
+
+.code-input {
+  background: var(--bg-code-input);
+  border-radius: 4px;
+  padding: 12px;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 14px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+  text-align: left;
+}
+
+/* Syntax highlighting */
+.keyword {
+  color: var(--accent-purple);
+}
+
+.function {
+  color: var(--accent-yellow);
+}
+
+.string {
+  color: var(--accent-green);
+}
+
+.variable {
+  color: var(--accent-blue);
+}
+
+.comment {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.number {
+  color: var(--accent-green);
+}
+
+.operator {
+  color: var(--text-secondary);
+}
+
+.builtin {
+  color: var(--accent-blue);
+}
+
+/* ============================================
+   MARKDOWN CELLS
+   ============================================ */
+
+.markdown-cell .cell-gutter {
+  /* Empty gutter for markdown cells */
+}
+
+.markdown-cell .cell-body {
+  padding: 12px 16px 12px 0;
+  max-width: 55ch;
+}
+
+.markdown-cell h1 {
+  font-size: 28px;
+  font-weight: 600;
+  margin: 0 0 16px 0;
+  color: var(--text-primary);
+}
+
+.markdown-cell h2 {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 24px 0 16px 0;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.markdown-cell h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 20px 0 12px 0;
+  color: var(--text-secondary);
+}
+
+.markdown-cell p {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.markdown-cell strong,
+.markdown-cell b {
+  color: var(--accent-orange);
+  font-weight: 500;
+}
+
+.markdown-cell a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.markdown-cell a:hover {
+  text-decoration: underline;
+}
+
+/* ============================================
+   OUTPUT CELLS
+   ============================================ */
+
+.output-cell .cell-body {
+  padding: 0;
+}
+
+/* ============================================
+   DATAFRAME OUTPUT
+   ============================================ */
+
+.dataframe-output {
+  overflow-x: auto;
+}
+
+.dataframe {
+  border-collapse: collapse;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 13px;
+  width: 100%;
+  margin: 8px 0;
+}
+
+.dataframe thead {
+  background: var(--bg-secondary);
+}
+
+.dataframe th {
+  color: var(--text-secondary);
+  font-weight: 600;
+  text-align: left;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+}
+
+.dataframe td {
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.dataframe td.index {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.dataframe tbody tr:hover {
+  background: var(--bg-cell);
+}
+
+/* ============================================
+   NAVIGATION OUTPUT (Homepage)
+   ============================================ */
+
+.nav-output {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  background: var(--bg-cell);
+  border: 1px solid var(--border-color);
+  border-left: 3px solid transparent;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover {
+  background: var(--bg-cell-hover);
+  border-color: var(--border-color);
+  border-left-color: var(--accent-blue);
+}
+
+.nav-icon {
+  font-size: 24px;
+  flex-shrink: 0;
+}
+
+.nav-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.nav-title {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.nav-link:hover .nav-title {
+  color: var(--accent-blue);
+}
+
+.nav-arrow {
+  opacity: 0.6;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover .nav-arrow {
+  opacity: 1;
+  transform: translateX(4px);
+}
+
+.nav-desc {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.nav-meta {
+  font-size: 13px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+}
+
+/* ============================================
+   LIST CONTENT OUTPUT (List Pages)
+   ============================================ */
+
+.list-content {
+  max-width: 55ch;
+  font-size: 16px;
+  line-height: 1.6;
+  padding: 12px 0;
+  text-align: left;
+}
+
+.list-content h1 {
+  font-size: 28px;
+  font-weight: 600;
+  margin: 0 0 24px 0;
+  color: var(--text-primary);
+}
+
+.list-content h2 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 24px 0 12px 0;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.list-content h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 20px 0 12px 0;
+  color: var(--text-secondary);
+}
+
+.list-content h4 {
+  font-size: 15px;
+  font-weight: 500;
+  margin: 16px 0 8px 0;
+  color: var(--text-secondary);
+}
+
+.list-content p {
+  margin: 8px 0;
+  line-height: 1.6;
+}
+
+.list-content a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.list-content a:hover {
+  text-decoration: underline;
+  color: var(--link-hover);
+}
+
+.list-content ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.list-content li {
+  margin: 6px 0;
+}
+
+/* ============================================
+   WIDGET CELLS (Substack embed, etc.)
+   ============================================ */
+
+.widget-cell .cell-body {
+  padding: 20px 0;
+}
+
+.widget-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.widget-container iframe {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  width: 100%;
+  max-width: 480px;
+  height: 320px;
+}
+
+/* ============================================
+   MOBILE RESPONSIVENESS
+   ============================================ */
+
+@media (max-width: 768px) {
+  .notebook {
+    max-width: 90%;
+    padding: 20px 12px 40px;
+  }
+
+  .list-content,
+  .markdown-cell .cell-body {
+    max-width: 100%;
+  }
+
+  .list-content h1 {
+    font-size: 28px;
+  }
+
+  .list-content h2 {
+    font-size: 24px;
+  }
+
+  .list-content h3 {
+    font-size: 20px;
+  }
+
+  .list-content h4 {
+    font-size: 18px;
+  }
+
+  .list-content p {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 640px) {
+  .cell-gutter {
+    width: 35px;
+    font-size: 11px;
+  }
+
+  .code-input {
+    font-size: 13px;
+  }
+
+  .dataframe {
+    font-size: 11px;
+  }
+
+  .dataframe th,
+  .dataframe td {
+    padding: 6px 8px;
+  }
+
+  .nav-link {
+    padding: 10px 12px;
+    gap: 12px;
+  }
+
+  .nav-icon {
+    font-size: 20px;
+  }
+
+  .nav-title {
+    font-size: 15px;
+  }
+
+  .nav-desc {
+    font-size: 12px;
+  }
+
+  .nav-meta {
+    font-size: 12px;
+  }
+
+  .widget-container iframe {
+    max-width: 100%;
+    height: 280px;
+  }
+}

--- a/hugo-site/static/shared.css
+++ b/hugo-site/static/shared.css
@@ -1,0 +1,163 @@
+/* ============================================
+   SHARED STYLES - Loaded on every page
+   ============================================
+   - Inter font declarations
+   - Shared CSS variables (book colors)
+   - Notebook header styling
+   - Blog wrapper/container helpers
+   ============================================ */
+
+/* ============================================
+   FONT FACE DECLARATIONS
+   ============================================ */
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url('/assets/fonts/InterVariable.woff2') format('woff2-variations');
+  font-named-instance: 'Regular';
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: italic;
+  font-weight: 100 900;
+  font-display: swap;
+  src: url('/assets/fonts/InterVariable-Italic.woff2') format('woff2-variations');
+  font-named-instance: 'Italic';
+}
+
+/* ============================================
+   CSS VARIABLES - Shared across all pages
+   ============================================ */
+
+:root {
+  /* Book rating colors */
+  --book-green: #a8e6a0;  /* 9-10/10 ratings */
+  --book-blue: #64b5f6;   /* 7-8/10 ratings */
+  --book-gray: #b0b0b0;   /* 5-6/10 ratings */
+
+  /* Notebook header colors */
+  --header-bg: #252526;
+  --header-border: #3c3c3c;
+  --header-text: #e0e0e0;
+  --kernel-green: #81c784;
+
+  /* Accent colors */
+  --accent-blue: #4fc3f7;
+  --accent-orange: #ffb74d;
+}
+
+/* ============================================
+   NOTEBOOK HEADER - Persistent across all pages
+   ============================================ */
+
+.notebook-header {
+  background: var(--header-bg);
+  border-bottom: 1px solid var(--header-border);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  z-index: 1000;
+  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+}
+
+.notebook-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.notebook-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--header-text);
+  text-decoration: none;
+  font-size: 13px;
+  transition: opacity 0.2s ease;
+}
+
+.notebook-title:hover {
+  opacity: 0.8;
+}
+
+.notebook-title .icon {
+  font-size: 16px;
+}
+
+.kernel-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--header-text);
+  font-size: 12px;
+}
+
+.kernel-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--kernel-green);
+  display: inline-block;
+}
+
+/* Mobile responsiveness for notebook header */
+@media (max-width: 640px) {
+  .notebook-toolbar {
+    flex-wrap: wrap;
+    padding: 6px 12px;
+  }
+
+  .notebook-title {
+    font-size: 12px;
+  }
+
+  .kernel-indicator span:not(.kernel-dot) {
+    display: none; /* Hide "Maksym Sherman (active)" text, keep dot */
+  }
+}
+
+/* ============================================
+   BLOG WRAPPER & CONTAINER HELPERS
+   Used by blog posts with main.css typography
+   ============================================ */
+
+.blog-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 30px 20px 50px;
+}
+
+.blog-container {
+  max-width: 55ch;
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .blog-wrapper {
+    padding: 20px 10px 50px;
+  }
+
+  .blog-container {
+    max-width: 80%;
+  }
+}
+
+/* ============================================
+   FONT FEATURE SETTINGS & BODY PADDING
+   Enable ligatures for Inter font
+   Add padding for fixed header
+   ============================================ */
+
+body {
+  font-feature-settings: 'liga' 1, 'calt' 1;
+  padding-top: 40px; /* Account for fixed header */
+}


### PR DESCRIPTION
## Summary

Complete website redesign with Jupyter notebook-inspired interface. This brings a fresh, technical aesthetic to the site while maintaining excellent readability.

## Changes

**Notebook UI (homepage + list pages):**
- Cell-based layout with execution counts (`In [n]:`, `Out[n]:`)
- Python syntax highlighting in code cells
- DataFrame output for personal information
- Widget cell for Substack newsletter
- Navigation styled as notebook output

**Blog posts:**
- Notebook header for branding
- Original typography preserved (55ch reading width)
- No notebook cells (optimal reading experience)

**Technical:**
- Conditional CSS loading strategy
- Reusable notebook-header partial
- VS Code dark theme palette
- Golden yellow links (#ffcc00)
- Fixed header positioning
- Mobile-responsive design

## Testing

✅ Desktop browser (Chrome, 1080px)
✅ Mobile browser (Chrome, 375px)
✅ All navigation pages verified
✅ 4 blog posts tested (various content types)

## Files Changed

- 12 files modified
- 1,202 insertions, 181 deletions
- New: notebook.css, shared.css, notebook-header.html

Ready for production deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)