### PR TITLE
Add LLM-friendly structured data and semantic HTML

### DIFF
--- a/hugo-site/archetypes/posts.md
+++ b/hugo-site/archetypes/posts.md
@@ -1,0 +1,10 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+description: "Brief summary of the post (max 160 characters)"
+---
+
+<h1>{{ replace .Name "-" " " | title }}</h1>
+<h5><time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2nd, 2006" }}</time></h5>
+
+<p>Your content here...</p>

--- a/hugo-site/content/posts/7powers-vs-blockchain.html
+++ b/hugo-site/content/posts/7powers-vs-blockchain.html
@@ -1,9 +1,11 @@
 ---
 title: "7 Powers vs. Blockchain"
+date: 2023-02-23
+description: "Hamilton Helmer's 7 Powers framework applied to blockchain, examining how competitive advantages differ in crypto businesses."
 ---
 
 <h1>7 Powers vs. Blockchain</h1>
-<h5>February 23rd, 2023</h5>
+<h5><time datetime="2023-02-23">February 23rd, 2023</time></h5>
 
 <p>
   Hamilton Helmer’s

--- a/hugo-site/content/posts/art-clustering-in-renaissance-florence.html
+++ b/hugo-site/content/posts/art-clustering-in-renaissance-florence.html
@@ -1,8 +1,10 @@
 ---
 title: "Art Clustering in Renaissance Florence"
+date: 2024-05-16
+description: "Renaissance Florence's art cluster arose from agglomeration economies: patronage as specialized input, labor pooling, and formal goldsmith training."
 ---
 <h1>Art Clustering in Renaissance Florence</h1>
-<h5>May 16th, 2024</h5>
+<h5><time datetime="2024-05-16">May 16th, 2024</time></h5>
 
 <h5><a href="pdfs/Art_Clustering_in_Renaissance_Florence.pdf">  Link to a fully cited version of this paper</a></h5>
 

--- a/hugo-site/content/posts/beyond-blockchain-marketplaces.html
+++ b/hugo-site/content/posts/beyond-blockchain-marketplaces.html
@@ -1,9 +1,11 @@
 ---
 title: "Beyond Blockchain Marketplaces"
+date: 2022-08-27
+description: "Blockchain marketplaces should be open and non-extractive, as centralized marketplaces with fees can't endure on systems where assets are stored on open backends."
 ---
 
 <h1>Beyond Blockchain Marketplaces</h1>
-<h5>August 27th, 2022</h5>
+<h5><time datetime="2022-08-27">August 27th, 2022</time></h5>
 
 <p>
   Marketplaces are places where people gather to trade. In ancient times,

--- a/hugo-site/content/posts/boi-favorite-book.html
+++ b/hugo-site/content/posts/boi-favorite-book.html
@@ -1,12 +1,14 @@
 ---
 title: "The Beginning of Infinity - My Favorite Book"
+date: 2025-06-15
+description: "When I mention that The Beginning of Infinity is the most impactful book I've ever read, people often ask me to summarize the book."
 ---
 
 
 
 <h1 id="the-beginning-of-infinity-my-favorite-book">The Beginning of Infinity - My Favorite Book</h1>
 
-<h5 id="date">June 15th, 2025</h5>
+<h5 id="date"><time datetime="2025-06-15">June 15th, 2025</time></h5>
 
 <p>When I mention that The Beginning of Infinity (BoI) is the most impactful book I've ever read, people often ask me to summarize the book. </p>
 

--- a/hugo-site/content/posts/knowledge-without-explanation.html
+++ b/hugo-site/content/posts/knowledge-without-explanation.html
@@ -1,9 +1,11 @@
 ---
 title: "Knowledge without Explanation"
+date: 2024-02-11
+description: "Humans can acquire knowledge without a well-understood explanation, as demonstrated by Semmelweis with handwashing and ChatGPT with language."
 ---
 
 <h1>Knowledge without Explanation</h1>
-<h5>February 11th, 2024</h5>
+<h5><time datetime="2024-02-11">February 11th, 2024</time></h5>
 
 <p>
   <em

--- a/hugo-site/content/posts/live-nation.html
+++ b/hugo-site/content/posts/live-nation.html
@@ -1,9 +1,11 @@
 ---
 title: "Live Nation Overview"
+date: 2023-12-08
+description: "Live Nation is the largest live entertainment company in the world, operating through concerts, ticketing, and advertising segments."
 ---
 
 <h1>Live Nation Overview</h1>
-<h5>December 8th, 2023</h5>
+<h5><time datetime="2023-12-08">December 8th, 2023</time></h5>
 
 <h2><strong>Business Model</strong></h2>
 <p>

--- a/hugo-site/content/posts/men-and-rubber.html
+++ b/hugo-site/content/posts/men-and-rubber.html
@@ -1,9 +1,11 @@
 ---
 title: "Men and Rubber (Book Notes)"
+date: 2023-08-16
+description: "Notes on Men and Rubber by Harvey Firestone, founder of Firestone Tire and Rubber Company, covering thinking, business judgment, and entrepreneurship."
 ---
 
 <h1>Men and Rubber (Book Notes)</h1>
-<h5>August 16th, 2023</h5>
+<h5><time datetime="2023-08-16">August 16th, 2023</time></h5>
 
 <p>
   Excellent book. Men and Rubber was originally published in 1926 by Harvey

--- a/hugo-site/content/posts/newsletter-publishing-platforms.html
+++ b/hugo-site/content/posts/newsletter-publishing-platforms.html
@@ -1,9 +1,11 @@
 ---
 title: "The Future of Substack and Newsletter Publishing Platforms"
+date: 2023-05-16
+description: "Newsletter platforms have disintermediated traditional media, but as the market saturates, large creators will migrate off Substack for cheaper alternatives."
 ---
 
 <h1>The Future of Substack and Newsletter Publishing Platforms</h1>
-<h5>May 16th, 2023</h5>
+<h5><time datetime="2023-05-16">May 16th, 2023</time></h5>
 <h5>Co-authored with Lucas Romualdo</h5>
 
 <h5><a href="pdfs/Newsletter_Publishing_Platforms.pdf"> Link to a fully cited version of this paper</a></h5>

--- a/hugo-site/content/posts/perverse-incentives-and-airdrops.html
+++ b/hugo-site/content/posts/perverse-incentives-and-airdrops.html
@@ -1,9 +1,11 @@
 ---
 title: "Perverse Incentives and Airdrops"
+date: 2021-12-03
+description: "Airdrops create perverse incentives for stakeholders with insider information to conduct Sybil attacks and profit from upcoming token distributions."
 ---
 
 <h1>Perverse Incentives and Airdrops</h1>
-<h5>December 3rd, 2021</h5>
+<h5><time datetime="2021-12-03">December 3rd, 2021</time></h5>
 
 <p>
   An “airdrop” is a distribution of crypto tokens for free (Pruden and Chokshi

--- a/hugo-site/content/posts/reasoning-by-inertia.html
+++ b/hugo-site/content/posts/reasoning-by-inertia.html
@@ -1,9 +1,11 @@
 ---
 title: "Reasoning by Inertia"
+date: 2024-02-03
+description: "We easily fool ourselves that we are reasoning by analogy when we are actually reasoning by inertia—continuing past actions without critical thinking."
 ---
 
 <h1>Reasoning by Inertia</h1>
-<h5>February 3rd, 2024</h5>
+<h5><time datetime="2024-02-03">February 3rd, 2024</time></h5>
 
 <p>
   Two main types of reasoning are reasoning by analogy and reasoning from

--- a/hugo-site/content/posts/some-thoughts.html
+++ b/hugo-site/content/posts/some-thoughts.html
@@ -1,9 +1,11 @@
 ---
 title: "Some Thoughts"
+date: 2023-09-23
+description: "A collection of thoughts on delayed gratification, imperfection, counterfactuals, time horizons, and independent thinking."
 ---
 
 <h1>Some Thoughts</h1>
-<h5>September 23th, 2023</h5>
+<h5><time datetime="2023-09-23">September 23th, 2023</time></h5>
 
 <ol>
   <li><p>Delayed gratification is a sign of civilization</p></li>

--- a/hugo-site/content/posts/soulbound(less)-tokens.html
+++ b/hugo-site/content/posts/soulbound(less)-tokens.html
@@ -1,11 +1,13 @@
 ---
 title: "Soulbound(less) Tokens"
 url: /p/soulbound(less)-tokens.html
+date: 2025-02-09
+description: "Vitalik Buterin introduced soulbound tokens as non-transferable NFTs, but fundamental technical limitations make true non-transferability impossible to enforce on the blockchain."
 ---
 
 <h1 id="soulboundless-tokens">Soulbound(less) Tokens</h1>
 
-<h5 id="february-9th-2025">February 9th, 2025</h5>
+<h5 id="february-9th-2025"><time datetime="2025-02-09">February 9th, 2025</time></h5>
 
 <p>In January 2022, Vitalik Buterin introduced the concept of <a href="https://vitalik.eth.limo/general/2022/01/26/soulbound.html">soulbound tokens</a>—NFTs that cannot be transferred once minted. While Vitalik discussed the use of soulbound NFTs for governance rights and certificates like drivers licenses and university degrees, fundamental technical limitations make true non-transferability impossible to enforce on the blockchain.</p>
 

--- a/hugo-site/content/posts/striking_while_the_iron_is_hot.html
+++ b/hugo-site/content/posts/striking_while_the_iron_is_hot.html
@@ -1,5 +1,7 @@
 ---
 title: "Lyndon Johnson and Robert Caro: Striking While the Iron is Hot"
+date: 2025-10-20
+description: "Johnson's extraordinary legislative success stemmed from a crucial ability: the capacity to recognize fleeting opportunities and seize them instantly."
 ---
 
 
@@ -13,7 +15,7 @@ The Passage of Power: 978-0307960467
 Working: 978-0593081914
  -->
 
-<h5>October 20, 2025</h5>
+<h5><time datetime="2025-10-20">October 20, 2025</time></h5>
 
 <blockquote style="max-width: 85%; margin: 0 auto 20px auto;">
     <p> President Kennedy’s eloquence was designed to make men think; President Johnson’s hammer blows are designed to make men act. </p>

--- a/hugo-site/content/posts/the-known-world.html
+++ b/hugo-site/content/posts/the-known-world.html
@@ -1,9 +1,11 @@
 ---
 title: "The Known World"
+date: 2021-12-17
+description: "Edward Jones explores a society built on slavery, raising questions about what knowledge prevents you from knowing and what action prevents you from doing."
 ---
 
 <h1>The Known World</h1>
-<h5>December 17th, 2021</h5>
+<h5><time datetime="2021-12-17">December 17th, 2021</time></h5>
 
 <p>
   In <em>The Known World,</em> Edward Jones explores the world of Manchester

--- a/hugo-site/content/posts/to-the-lighthouse.html
+++ b/hugo-site/content/posts/to-the-lighthouse.html
@@ -1,9 +1,11 @@
 ---
 title: "To The Lighthouse"
+date: 2021-10-18
+description: "Virginia Woolf explores darkness, revealing that the meaning of life comes from little daily miracles—illuminations struck unexpectedly in the dark."
 ---
 
 <h1>To The Lighthouse</h1>
-<h5>October 18th, 2021</h5>
+<h5><time datetime="2021-10-18">October 18th, 2021</time></h5>
 
 <p>
   In <em>To the Lighthouse</em>, Virginia Woolf explores darkness, an elusive

--- a/hugo-site/content/posts/unpredictable.html
+++ b/hugo-site/content/posts/unpredictable.html
@@ -1,12 +1,14 @@
 ---
 title: "Unpredictable"
+date: 2025-07-13
+description: "Human creativity makes even our most well-reasoned long-term forecasts fundamentally unreliable."
 ---
 
 
 
 <h1 id="unpredictable">Unpredictable</h1>
 
-<h5>July 13th, 2025</h5>
+<h5><time datetime="2025-07-13">July 13th, 2025</time></h5>
 
 <p> In <em>The Beginning of Infinity</em>, David Deutsch asks the reader to consider  "what it would have taken for scientists [in 1902] to forecast, say, carbon-dioxide emissions for the twentieth century:" </p>
 

--- a/hugo-site/hugo.toml
+++ b/hugo-site/hugo.toml
@@ -3,11 +3,16 @@ baseURL = 'https://msherman.xyz/'
 languageCode = 'en-us'
 title = 'Maksym Sherman'
 
-# Don't generate RSS, sitemap etc for now
-disableKinds = ['RSS', 'sitemap', 'taxonomy', 'term']
+# Don't generate taxonomy and term pages
+disableKinds = ['taxonomy', 'term']
 
 # Use actual .html files instead of directories (for relative path compatibility)
 uglyURLs = true
+
+# Site metadata for SEO and LLM consumption
+[params]
+  author = "Maksym Sherman"
+  description = "Personal website of Maksym Sherman - exploring great work, ambition, and explanations."
 
 # Keep .html extensions for backwards compatibility
 [permalinks]

--- a/hugo-site/layouts/_default/baseof.html
+++ b/hugo-site/layouts/_default/baseof.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="{{ if .Description }}{{ .Description }}{{ else if .IsHome }}{{ .Site.Params.description }}{{ else }}{{ .Summary | plainify | truncate 160 }}{{ end }}">
+  <meta name="author" content="{{ .Site.Params.author }}">
+  <link rel="canonical" href="{{ .Permalink }}">
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-TR23NDH2MP"></script>
   <script>
@@ -31,6 +34,62 @@
       height: auto;
     }
   </style>
+
+  <!-- Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "{{ .Site.Title }}",
+    "url": "{{ .Site.BaseURL }}",
+    "author": {
+      "@type": "Person",
+      "name": "{{ .Site.Params.author }}",
+      "url": "{{ .Site.BaseURL }}"
+    }
+  }
+  </script>
+
+  {{ if .IsHome }}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Maksym Sherman",
+    "url": "{{ .Site.BaseURL }}",
+    "jobTitle": "Data Consultant",
+    "description": "I believe in great work, ambition, and obsessiveness. I seek to understand the world through better explanations."
+  }
+  </script>
+  {{ end }}
+
+  {{ if and (not .IsHome) (eq .Type "posts") }}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": {{ .Title | jsonify }},
+    "author": {
+      "@type": "Person",
+      "name": "{{ .Site.Params.author }}",
+      "url": "{{ .Site.BaseURL }}"
+    },
+    {{ with .Params.date }}
+    "datePublished": "{{ .Format "2006-01-02T15:04:05Z07:00" }}",
+    {{ end }}
+    {{ with .Params.description }}
+    "description": {{ . | jsonify }},
+    {{ else }}
+    "description": {{ .Summary | plainify | truncate 160 | jsonify }},
+    {{ end }}
+    "url": "{{ .Permalink }}",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "{{ .Permalink }}"
+    }
+  }
+  </script>
+  {{ end }}
 </head>
 <body>
   {{- block "main" . }}{{- end }}

--- a/hugo-site/layouts/_default/single.html
+++ b/hugo-site/layouts/_default/single.html
@@ -1,5 +1,12 @@
 {{ define "main" }}
 {{ partial "notebook-header.html" . }}
 
-{{ .Content }}
+<article itemscope itemtype="https://schema.org/BlogPosting">
+  <meta itemprop="headline" content="{{ .Title }}">
+  <meta itemprop="author" content="{{ .Site.Params.author }}">
+  {{ with .Params.date }}<meta itemprop="datePublished" content="{{ .Format "2006-01-02" }}">{{ end }}
+  {{ with .Description }}<meta itemprop="description" content="{{ . }}">{{ end }}
+
+  {{ .Content }}
+</article>
 {{ end }}


### PR DESCRIPTION
## Summary

- Adds JSON-LD structured data (WebSite, Person, BlogPosting schemas) to all pages for LLM consumption
- Enables RSS feed and sitemap generation for better discoverability
- Adds semantic HTML tags (`<article>`, `<time>`) and meta tags (description, author, canonical)
- Updates all 16 blog posts with machine-readable front matter (date, description)
- Creates post archetype template for consistent metadata in future posts

All changes preserve the Jupyter notebook aesthetic with **zero visual changes**.

## Test plan

- [x] Build site with `hugo --noHTTPCache` - completes without errors
- [x] Verify `public/sitemap.xml` exists with 23 URLs
- [x] Verify `public/index.xml` (RSS feed) exists
- [x] Check blog post HTML for proper JSON-LD BlogPosting schema with dates
- [x] Check homepage HTML for Person schema with jobTitle and description
- [ ] Validate structured data with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Validate with [Schema.org validator](https://validator.schema.org/)
- [ ] Visual regression test - confirm zero visual changes on homepage, blog list, and individual posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)